### PR TITLE
담보총액, 현재 한도, 담보유지비율 조회 api 구현

### DIFF
--- a/OFZ-common/src/main/java/org/ofz/marginRequirement/entity/MarginRequirementHistory.java
+++ b/OFZ-common/src/main/java/org/ofz/marginRequirement/entity/MarginRequirementHistory.java
@@ -1,8 +1,13 @@
 package org.ofz.marginRequirement.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "margin_requirement_history")
 public class MarginRequirementHistory {
 
@@ -13,29 +18,25 @@ public class MarginRequirementHistory {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @Column(name = "mortgage_sum", nullable = false)
+    private int mortgageSum;
+
+    @Column(name = "today_limit", nullable = false)
+    private int todayLimit;
+
     @Column(name = "margin_requirement", nullable = false)
     private int marginRequirement;
 
-    public MarginRequirementHistory() {}
-
-    public MarginRequirementHistory(Long userId, int marginRequirement) {
+    public MarginRequirementHistory(Long userId, int mortgageSum, int todayLimit, int marginRequirement) {
         this.userId = userId;
+        this.mortgageSum = mortgageSum;
+        this.todayLimit = todayLimit;
         this.marginRequirement = marginRequirement;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public Long getUserId() {
-        return userId;
-    }
-
-    public int getMarginRequirement() {
-        return marginRequirement;
-    }
-
-    public void changeMarginRequirement(int marginRequirement) {
+    public void updateValues(int mortgageSum, int todayLimit, int marginRequirement) {
+        this.mortgageSum = mortgageSum;
+        this.todayLimit = todayLimit;
         this.marginRequirement = marginRequirement;
     }
 }

--- a/OFZ-common/src/main/java/org/ofz/marginRequirement/repository/MarginRequirementHistoryRepository.java
+++ b/OFZ-common/src/main/java/org/ofz/marginRequirement/repository/MarginRequirementHistoryRepository.java
@@ -2,10 +2,18 @@ package org.ofz.marginRequirement.repository;
 
 import org.ofz.marginRequirement.entity.MarginRequirementHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MarginRequirementHistoryRepository extends JpaRepository<MarginRequirementHistory, Long> {
-    Optional<MarginRequirementHistory> findByUserId(Long userId);
+    @Query("SELECT m FROM MarginRequirementHistory m WHERE m.userId = :userId")
+    Optional<MarginRequirementHistory> findByUserId(@Param("userId") Long userId);
+
+    List<MarginRequirementHistory> findByMarginRequirementLessThanEqual(int maxRequirement);
+
 }

--- a/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementController.java
+++ b/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementController.java
@@ -3,10 +3,7 @@ package org.ofz.marginRequirement;
 import org.ofz.marginRequirement.entity.MarginRequirementHistory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,6 +23,14 @@ public class MarginRequirementController {
     public ResponseEntity<List<MarginRequirementHistory>> getAllUserMarginRequirements() {
         List<MarginRequirementHistory> marginRequirements = marginRequirementService.getAllUserMarginRequirements();
         return ResponseEntity.ok(marginRequirements);
+    }
+
+    // margin_requirement가 특정 값 이하인 유저 조회
+    @GetMapping("/user-margin-requirements-under")
+    public ResponseEntity<List<MarginRequirementHistory>> getUsersWithMarginRequirementUnder(
+            @RequestParam(value = "limit", defaultValue = "160") int limit) {
+        List<MarginRequirementHistory> usersUnderLimit = marginRequirementService.getUsersWithMarginRequirementUnder(limit);
+        return ResponseEntity.ok(usersUnderLimit);
     }
 
     @PostMapping("/process-all-user-limits")

--- a/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementService.java
+++ b/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementService.java
@@ -50,7 +50,7 @@ public class MarginRequirementService {
         return marginRequirementHistoryRepository.findAll();
     }
 
-    // margin_requirement가 160 이하인 유저 조회
+    // margin_requirement가 limit 이하인 유저 조회
     public List<MarginRequirementHistory> getUsersWithMarginRequirementUnder(int limit) {
         try {
             List<MarginRequirementHistory> results = marginRequirementHistoryRepository.findByMarginRequirementLessThanEqual(limit);
@@ -111,8 +111,8 @@ public class MarginRequirementService {
                         .sum();
 
                 // 현재 한도 비율 계산
-                double creditLimit = payment.getCreditLimit();
-                final double currentLimitRatio;
+                final int creditLimit = payment.getCreditLimit();
+                double currentLimitRatio;
                 int marginRequirement;
                 if (creditLimit == 0) {
                     logger.error("유저 ID: {}, 크레딧 한도가 0이므로 margin_requirement를 -1로 설정합니다.", userId);
@@ -125,10 +125,10 @@ public class MarginRequirementService {
 
                 // 기존의 MarginRequirementHistory 찾기 또는 새로 생성
                 MarginRequirementHistory history = marginRequirementHistoryRepository.findByUserId(userId)
-                        .orElseGet(() -> new MarginRequirementHistory(userId, mortgageSum, (int) Math.floor(currentLimitRatio), marginRequirement));
+                        .orElseGet(() -> new MarginRequirementHistory(userId, mortgageSum, creditLimit, marginRequirement));
 
-                // mortgageSum, currentLimitRatio 및 margin_requirement 값 업데이트
-                history.updateValues(mortgageSum, (int) Math.floor(currentLimitRatio), marginRequirement);
+                // mortgageSum, currentLimit 및 margin_requirement 값 업데이트
+                history.updateValues(mortgageSum, creditLimit, marginRequirement);
 
                 // 최대 한도 비율 계산
                 if (maxLimit == 0) {

--- a/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementService.java
+++ b/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementService.java
@@ -5,10 +5,7 @@ import org.ofz.management.repository.MortgagedStockRepository;
 import org.ofz.management.repository.StockInformationRepository;
 import org.ofz.management.utils.StockStability;
 import org.ofz.marginRequirement.entity.MarginRequirementHistory;
-import org.ofz.marginRequirement.exception.DatabaseAccessException;
-import org.ofz.marginRequirement.exception.GenericServiceException;
-import org.ofz.marginRequirement.exception.PriceNotFoundException;
-import org.ofz.marginRequirement.exception.StockInformationNotFoundException;
+import org.ofz.marginRequirement.exception.*;
 import org.ofz.marginRequirement.repository.MarginRequirementHistoryRepository;
 import org.ofz.payment.Payment;
 import org.ofz.payment.PaymentRepository;
@@ -58,6 +55,10 @@ public class MarginRequirementService {
                 logger.warn("쿼리 결과가 null입니다. 빈 리스트를 반환합니다.");
                 return Collections.emptyList();
             }
+//            if (results == null || results.isEmpty()) {
+//                logger.warn("쿼리 결과가 없습니다. 한도: {}", limit);
+//                throw new NoDataFoundException("해당 조건에 맞는 데이터가 존재하지 않습니다.");
+//            }
             return results;
         } catch (DataAccessException e) {
             logger.error("데이터베이스 접근 중 오류 발생: {}", e.getMessage(), e);
@@ -119,7 +120,7 @@ public class MarginRequirementService {
                     marginRequirement = -1;
                     currentLimitRatio = 0;
                 } else {
-                    currentLimitRatio = (mortgageSum / creditLimit) * 100;
+                    currentLimitRatio = ((double) mortgageSum / creditLimit) * 100;
                     marginRequirement = (int) Math.floor(currentLimitRatio);
                 }
 

--- a/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementService.java
+++ b/OFZ-schedule/src/main/java/org/ofz/marginRequirement/MarginRequirementService.java
@@ -5,6 +5,8 @@ import org.ofz.management.repository.MortgagedStockRepository;
 import org.ofz.management.repository.StockInformationRepository;
 import org.ofz.management.utils.StockStability;
 import org.ofz.marginRequirement.entity.MarginRequirementHistory;
+import org.ofz.marginRequirement.exception.DatabaseAccessException;
+import org.ofz.marginRequirement.exception.GenericServiceException;
 import org.ofz.marginRequirement.exception.PriceNotFoundException;
 import org.ofz.marginRequirement.exception.StockInformationNotFoundException;
 import org.ofz.marginRequirement.repository.MarginRequirementHistoryRepository;
@@ -18,7 +20,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.ofz.redis.RedisUtil;
+import org.springframework.dao.DataAccessException;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -44,6 +48,24 @@ public class MarginRequirementService {
     // 전체 유저의 margin requirement 조회 메소드
     public List<MarginRequirementHistory> getAllUserMarginRequirements() {
         return marginRequirementHistoryRepository.findAll();
+    }
+
+    // margin_requirement가 160 이하인 유저 조회
+    public List<MarginRequirementHistory> getUsersWithMarginRequirementUnder(int limit) {
+        try {
+            List<MarginRequirementHistory> results = marginRequirementHistoryRepository.findByMarginRequirementLessThanEqual(limit);
+            if (results == null) {
+                logger.warn("쿼리 결과가 null입니다. 빈 리스트를 반환합니다.");
+                return Collections.emptyList();
+            }
+            return results;
+        } catch (DataAccessException e) {
+            logger.error("데이터베이스 접근 중 오류 발생: {}", e.getMessage(), e);
+            throw new DatabaseAccessException("데이터베이스 오류: 데이터 조회 중 문제가 발생했습니다.", e);
+        } catch (Exception e) {
+            logger.error("예기치 못한 오류가 발생했습니다: {}", e.getMessage(), e);
+            throw new GenericServiceException("서버 내부 오류: 예기치 못한 문제가 발생했습니다. 잠시 후 다시 시도해주세요.", e);
+        }
     }
 
     @Scheduled(cron = "0 0 0 * * ?") // 매일 자정 실행
@@ -90,11 +112,12 @@ public class MarginRequirementService {
 
                 // 현재 한도 비율 계산
                 double creditLimit = payment.getCreditLimit();
-                double currentLimitRatio = 0;
+                final double currentLimitRatio;
                 int marginRequirement;
                 if (creditLimit == 0) {
                     logger.error("유저 ID: {}, 크레딧 한도가 0이므로 margin_requirement를 -1로 설정합니다.", userId);
                     marginRequirement = -1;
+                    currentLimitRatio = 0;
                 } else {
                     currentLimitRatio = (mortgageSum / creditLimit) * 100;
                     marginRequirement = (int) Math.floor(currentLimitRatio);
@@ -102,13 +125,10 @@ public class MarginRequirementService {
 
                 // 기존의 MarginRequirementHistory 찾기 또는 새로 생성
                 MarginRequirementHistory history = marginRequirementHistoryRepository.findByUserId(userId)
-                        .orElse(new MarginRequirementHistory(userId, marginRequirement));
+                        .orElseGet(() -> new MarginRequirementHistory(userId, mortgageSum, (int) Math.floor(currentLimitRatio), marginRequirement));
 
-                // margin_requirement 값 업데이트
-                history.changeMarginRequirement(marginRequirement);
-
-                // 업데이트된 값 저장
-                marginRequirementHistoryRepository.save(history);
+                // mortgageSum, currentLimitRatio 및 margin_requirement 값 업데이트
+                history.updateValues(mortgageSum, (int) Math.floor(currentLimitRatio), marginRequirement);
 
                 // 최대 한도 비율 계산
                 if (maxLimit == 0) {
@@ -128,6 +148,7 @@ public class MarginRequirementService {
                     logger.info("유저 ID: {}, 현재 한도 비율이 140% 초과이므로 rateFlag를 true로 설정합니다.", userId);
                 }
 
+                marginRequirementHistoryRepository.save(history);
                 paymentRepository.save(payment);
 
             } catch (PriceNotFoundException | StockInformationNotFoundException e) {

--- a/OFZ-schedule/src/main/java/org/ofz/marginRequirement/exception/DatabaseAccessException.java
+++ b/OFZ-schedule/src/main/java/org/ofz/marginRequirement/exception/DatabaseAccessException.java
@@ -1,0 +1,7 @@
+package org.ofz.marginRequirement.exception;
+
+public class DatabaseAccessException extends RuntimeException {
+    public DatabaseAccessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/OFZ-schedule/src/main/java/org/ofz/marginRequirement/exception/GenericServiceException.java
+++ b/OFZ-schedule/src/main/java/org/ofz/marginRequirement/exception/GenericServiceException.java
@@ -1,0 +1,7 @@
+package org.ofz.marginRequirement.exception;
+
+public class GenericServiceException extends RuntimeException {
+    public GenericServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/OFZ-schedule/src/main/java/org/ofz/marginRequirement/exception/MarginRequirementExceptionHandler.java
+++ b/OFZ-schedule/src/main/java/org/ofz/marginRequirement/exception/MarginRequirementExceptionHandler.java
@@ -82,6 +82,28 @@ public class MarginRequirementExceptionHandler {
                 .build();
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+    // 데이터베이스 접근 오류에 대한 핸들러
+    @ExceptionHandler(DatabaseAccessException.class)
+    public ResponseEntity<ErrorResponseDTO> handleCustomDatabaseAccessException(DatabaseAccessException ex) {
+        logger.error("데이터베이스 접근 오류: {}", ex.getMessage(), ex);
+        ErrorResponseDTO errorResponse = ErrorResponseDTO.builder()
+                .timestamp(LocalDateTime.now())
+                .message("데이터베이스 접근 중 오류가 발생했습니다. 관리자에게 문의하세요.")
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // 일반적인 서비스 오류에 대한 핸들러
+    @ExceptionHandler(GenericServiceException.class)
+    public ResponseEntity<ErrorResponseDTO> handleGenericServiceException(GenericServiceException ex) {
+        logger.error("서비스 오류: {}", ex.getMessage(), ex);
+        ErrorResponseDTO errorResponse = ErrorResponseDTO.builder()
+                .timestamp(LocalDateTime.now())
+                .message("서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
 
     // 기타 예외에 대한 핸들러
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🌿 반영 브랜치
69-feature-담보유지비율-스케줄링-로직-구현 -> dev

## ⚒️ 구현 사항
1. 담보총액, 현재 한도, 담보유지비율 조회 api 구현
- 원하는 limit설정 시 그 이하인 유저를 보여줌
- 해당하는 값이 존재하지 않을 경우 빈 리스트 반환

2. 담보비율조회 스케줄링 시 담보총액, 현재 한도에 대해서 DB에 저장하도록 구현


## ✅ 테스트 결과
- 테스트 api :  GET `schedule/user-margin-requirements-under?limit={원하는 최댓값}`

<img width="600" alt="image" src="https://github.com/user-attachments/assets/141c94eb-017f-4a6d-86b9-e90168ddbf63">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0f8720d2-167d-4b1d-b457-1c56eb3afbf7">



- 값이 존재하지 않을 경우 빈 리스트 반환

<img width="600" alt="image" src="https://github.com/user-attachments/assets/b574a9ef-403e-46c2-8fd1-c02b774099ff">



