### PR TITLE
✨ hotfix: 알람 관련 로직 추가 및 알람 저장

### DIFF
--- a/OFZ-common/src/main/java/org/ofz/rabbitMQ/Publisher.java
+++ b/OFZ-common/src/main/java/org/ofz/rabbitMQ/Publisher.java
@@ -17,22 +17,10 @@ import java.util.Objects;
 public class Publisher<T extends Queueable> {
 
     private final RabbitTemplate rabbitTemplate;
-    private final RabbitAdmin rabbitAdmin;
-
-    private void configureQueue(String queueName) {
-        Map<String, Object> args = new HashMap<>();
-        args.put("x-message-ttl", Duration.ofHours(24).toMillis());
-        args.put("x-max-length", 10000);
-        args.put("x-max-length-bytes", 1048576);
-        Queue queue = new Queue(queueName, true, false, false, args);
-        rabbitAdmin.declareQueue(queue);
-    }
 
     public void sendMessage(T queueable) {
         String queueName = queueable.getQueueName();
-        if (!Objects.requireNonNull(rabbitAdmin.getQueueProperties(queueName)).isEmpty()) {
-            configureQueue(queueName);
-        }
-        rabbitTemplate.convertAndSend(queueable.getQueueName(), queueable);
+
+        rabbitTemplate.convertAndSend(queueName, queueable);
     }
 }

--- a/OFZ-common/src/main/java/org/ofz/rabbitMQ/QueueMaker.java
+++ b/OFZ-common/src/main/java/org/ofz/rabbitMQ/QueueMaker.java
@@ -1,0 +1,58 @@
+package org.ofz.rabbitMQ;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class QueueMaker {
+
+    @Bean
+    public Queue configureNotificationQueue() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-message-ttl", Duration.ofHours(24).toMillis());
+        args.put("x-max-length", 10000);
+        args.put("x-max-length-bytes", 1048576);
+        return new Queue("notification", true, false, false, args);
+    }
+
+    @Bean
+    public Queue configureAdminOffsetAllPaidQueue() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-message-ttl", Duration.ofHours(24).toMillis());
+        args.put("x-max-length", 10000);
+        args.put("x-max-length-bytes", 1048576);
+        return new Queue("adminOffsetAllPaid", true, false, false, args);
+    }
+
+    @Bean
+    public Queue configureAdminOffsetNotAllPaidQueue() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-message-ttl", Duration.ofHours(24).toMillis());
+        args.put("x-max-length", 10000);
+        args.put("x-max-length-bytes", 1048576);
+        return new Queue("adminOffsetNotAllPaid", true, false, false, args);
+    }
+
+    @Bean
+    public Queue configureSimpleQueue() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-message-ttl", Duration.ofHours(24).toMillis());
+        args.put("x-max-length", 10000);
+        args.put("x-max-length-bytes", 1048576);
+        return new Queue("simple", true, false, false, args);
+    }
+
+    @Bean
+    public Queue configureRepaymentQueue() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-message-ttl", Duration.ofHours(24).toMillis());
+        args.put("x-max-length", 10000);
+        args.put("x-max-length-bytes", 1048576);
+        return new Queue("repayment", true, false, false, args);
+    }
+}

--- a/OFZ-notification/src/main/java/org/ofz/notificationBox/entity/Notification.java
+++ b/OFZ-notification/src/main/java/org/ofz/notificationBox/entity/Notification.java
@@ -1,6 +1,7 @@
 package org.ofz.notificationBox.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ofz.notificationBox.NotificationType;
@@ -27,4 +28,13 @@ public class Notification {
 
     @Enumerated(EnumType.STRING)
     private NotificationType category;
+
+    @Builder
+    public Notification(String loginId, String title, String content, NotificationType notificationType) {
+        this.loginId = loginId;
+        this.title = title;
+        this.content = content;
+        this.category = notificationType;
+        this.createdAt = LocalDate.now();
+    }
 }


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가

## 🌿 반영 브랜치
71 -> dev

## ⚒️ 구현 사항
토큰이 캐싱 돼있으면 알람 요청보내고
캐싱돼있지 않으면 알람을 DB에만 저장하는 로직 추가
두가지 경우 모두 DB에 저장