### PR TITLE
Feat/59 asset domain

### DIFF
--- a/OFZ-api-gateway/src/main/resources/application.yml
+++ b/OFZ-api-gateway/src/main/resources/application.yml
@@ -119,7 +119,7 @@ spring:
         - id: asset-service-admin
           uri: lb://asset-service
           predicates:
-            - Path=/api/asset/rate-of-change/under
+            - Path=/api/asset/rate-of-change/under, /api/asset/calculate-rate-of-change
           filters:
             - StripPrefix=1
             

--- a/OFZ-asset/src/main/java/org/ofz/asset/dto/AssetHistoryRateRes.java
+++ b/OFZ-asset/src/main/java/org/ofz/asset/dto/AssetHistoryRateRes.java
@@ -1,21 +1,17 @@
 package org.ofz.asset.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class AssetHistoryRateRes {
-
     private Long id;
     private Long userId;
+    private int mortgageSum;
+    private int todayLimit;
+    private int marginRequirement;
     private double mortgageSumRateOfChange;
-
-    public AssetHistoryRateRes(Long id, Long userId, double mortgageSumRateOfChange) {
-        this.id = id;
-        this.userId = userId;
-        this.mortgageSumRateOfChange = mortgageSumRateOfChange;
-    }
-
 }

--- a/OFZ-asset/src/main/java/org/ofz/asset/repository/AssetHistoryRepository.java
+++ b/OFZ-asset/src/main/java/org/ofz/asset/repository/AssetHistoryRepository.java
@@ -35,7 +35,7 @@ public interface AssetHistoryRepository extends JpaRepository<AssetHistory, Long
     List<AssetHistory> findAllLatestByUser();
 
     // 담보총액 변동율이 특정 값 이하인 유저 조회
-    @Query("SELECT new org.ofz.asset.dto.AssetHistoryRateRes(ah.id, ah.userId, ah.mortgageSumRateOfChange) " +
+    @Query("SELECT new org.ofz.asset.dto.AssetHistoryRateRes(ah.id, ah.userId, ah.mortgageSum, ah.todayLimit, ah.marginRequirement, ah.mortgageSumRateOfChange) " +
             "FROM AssetHistory ah " +
             "WHERE ah.id IN (" +
             "    SELECT MAX(subAh.id) " +

--- a/OFZ-asset/src/main/resources/application.yml
+++ b/OFZ-asset/src/main/resources/application.yml
@@ -48,7 +48,8 @@ spring:
     username: ${LOCAL_ASSET_DB_USERNAME}
     password: ${LOCAL_ASSET_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
+  jpa:
+    show-sql: true
 secret:
   key:
     base64: ${SECRET_KEY_BASE64}


### PR DESCRIPTION
## 🔖 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 🌿 반영 브랜치
feat/59-asset-domain -> dev

## ⚒️ 구현 사항
담보총액 하락 시 전달하는 데이터 필드 추가

## ✅ 테스트 결과
- 어드민 페이지 담보총액 전날 대비 변동율 조회 API : GET asset/rate-of-change/under?limit={적용할 하락값(음수로 입력 필수)}
<img width="584" alt="image" src="https://github.com/user-attachments/assets/6c094e33-f6b0-4aa0-8064-fd7e60779b61">

